### PR TITLE
Removed transition grid after animation ends

### DIFF
--- a/hooks/transitions/gridRevealTransition.ts
+++ b/hooks/transitions/gridRevealTransition.ts
@@ -112,7 +112,7 @@ export class GridRevealTransition implements TransitionStrategy {
     public async end(): Promise<void> {
         return new Promise((resolve) => {
             const blocks = this.transitionBlocks.map((b) => b.element);
-            const transitionGrid = document.querySelector(".transition-grid") as HTMLElement;
+            const transitionGrid = document.getElementById(this.containerId) as HTMLElement;
 
             if (blocks.length === 0) {
                 resolve();


### PR DESCRIPTION
The transition grid was not properly removed after the animation ended so it left an overlay in the DOM, blocking all pointer events. Fixed the selection of the grid container so it's properly cleaned up after transition ends.